### PR TITLE
Expose attack utilities on DungeonScene

### DIFF
--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -8,7 +8,7 @@ import Player from '../classes/player.js';
 import Joystick from '../classes/joystick.js';
 import { createHUD, updatePlayerHud, updateWaveProgressText, showFloatingText, repositionHUD, updateSpecialAbilityUI } from '../utils/hudUtils.js';
 import { handleControls } from '../utils/controlUtils.js';
-import { fireAttack, projectileHitEnemy, projectileHitPlayer, playerHitEnemy } from '../utils/attackUtils.js';
+import { fireAttack, enemyFireAttack, projectileHitEnemy, projectileHitPlayer, playerHitEnemy } from '../utils/attackUtils.js';
 import { generatePlayerTexture, generateTatuZumbiTexture, generateAranhaDeDardoTexture, generateBossJiboiaTexture, generateWeaponTexture, generateProjectileTextures, generateIcons } from '../utils/assetUtils.js';
 import { useArrowRain, useShockwave } from '../utils/abilityUtils.js';
 
@@ -98,6 +98,9 @@ export default class DungeonScene extends Phaser.Scene {
 
         this.physics.add.overlap(this.playerAttacks, this.enemies, (proj, enemy) => projectileHitEnemy(this, proj, enemy), null, this);
         this.physics.add.overlap(this.player, this.enemyAttacks, (player, proj) => projectileHitPlayer(this, player, proj), null, this);
+
+        this.fireAttack = (dir) => fireAttack(this, dir);
+        this.enemyFireAttack = (enemy) => enemyFireAttack(this, enemy);
 
         this.cursors = this.input.keyboard.createCursorKeys();
         this.moveJoystick = new Joystick(this);

--- a/src/utils/controlUtils.js
+++ b/src/utils/controlUtils.js
@@ -1,4 +1,6 @@
 // Funções utilitárias de controle
+import { fireAttack } from './attackUtils.js';
+
 export function handleControls(scene) {
     const speed = scene.selectedClass.velocidade;
     scene.player.body.setVelocity(0);
@@ -20,13 +22,13 @@ export function handleControls(scene) {
 export function startJoystickAutoAttack(scene) {
     if (!scene.joystickAttackInterval) {
         let dir = scene.attackJoystick.fireDirection || new Phaser.Math.Vector2(0, -1);
-        scene.fireAttack(dir);
+        fireAttack(scene, dir);
         scene.joystickAttackInterval = scene.time.addEvent({
             delay: scene.selectedClass.attackCooldown,
             loop: true,
             callback: () => {
                 let dir = scene.attackJoystick.fireDirection || new Phaser.Math.Vector2(0, -1);
-                scene.fireAttack(dir);
+                fireAttack(scene, dir);
             }
         });
     }


### PR DESCRIPTION
## Summary
- call `fireAttack` directly from control utilities
- attach `fireAttack` and `enemyFireAttack` to `DungeonScene` for joystick and enemy AI usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f74d2bf948330bff879ef3227e5ad