### PR TITLE
Alias HUD helper imports in dungeon scene

### DIFF
--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -6,7 +6,14 @@ import { GameData, WaveConfig } from '../data/data.js';
 import Enemy from '../classes/enemy.js';
 import Player from '../classes/player.js';
 import Joystick from '../classes/joystick.js';
-import { createHUD, updatePlayerHud, updateWaveProgressText, showFloatingText, repositionHUD, updateSpecialAbilityUI } from '../utils/hudUtils.js';
+import {
+    createHUD,
+    updatePlayerHud as hudUpdate,
+    updateWaveProgressText as waveTextUpdate,
+    showFloatingText as floatingTextShow,
+    repositionHUD,
+    updateSpecialAbilityUI
+} from '../utils/hudUtils.js';
 import { handleControls } from '../utils/controlUtils.js';
 import { fireAttack, projectileHitEnemy, projectileHitPlayer, playerHitEnemy } from '../utils/attackUtils.js';
 import { generatePlayerTexture, generateTatuZumbiTexture, generateAranhaDeDardoTexture, generateBossJiboiaTexture, generateWeaponTexture, generateProjectileTextures, generateIcons } from '../utils/assetUtils.js';
@@ -173,15 +180,15 @@ export default class DungeonScene extends Phaser.Scene {
     }
 
     updatePlayerHud() {
-        updatePlayerHud(this);
+        hudUpdate(this);
     }
 
     updateWaveProgressText() {
-        updateWaveProgressText(this);
+        waveTextUpdate(this);
     }
 
     showFloatingText(txt, x, y, isCrit = false, color = '#ffdddd') {
-        showFloatingText(this, txt, x, y, isCrit, color);
+        floatingTextShow(this, txt, x, y, isCrit, color);
     }
 
     setupWaveSystem() {


### PR DESCRIPTION
## Summary
- Alias HUD utility imports to avoid clashing with scene method names
- Call the newly aliased helpers within the scene methods

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f74d4453c8330bbf708c9a352e671