### PR TITLE
Enable projectile physics and damage scaling

### DIFF
--- a/src/utils/abilityUtils.js
+++ b/src/utils/abilityUtils.js
@@ -6,7 +6,9 @@ export function useArrowRain(scene, targetPos) {
                 const angle = Phaser.Math.DegToRad(45 * a);
                 const proj = scene.playerAttacks.get(targetPos.x, targetPos.y, 'player-projectile-texture');
                 if (proj) {
+                    proj.enableBody(true, targetPos.x, targetPos.y, true, true);
                     proj.setActive(true).setVisible(true);
+                    proj.setData('damage', scene.player.getData('damage') * ability.damageMultiplier);
                     scene.physics.velocityFromRotation(angle, 350, proj.body.velocity);
                 }
             }


### PR DESCRIPTION
## Summary
- enable physics bodies for arrow rain projectiles
- scale projectile damage using ability damage multiplier

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f74d602288330b7dbda44b9e49bb6