### PR TITLE
Remove manual enemy iteration in DungeonScene

### DIFF
--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -157,9 +157,6 @@ export default class DungeonScene extends Phaser.Scene {
             return;
         }
         handleControls(this);
-        this.enemies.children.iterate(enemy => {
-            if (enemy && enemy.active) enemy.update(time, delta);
-        });
         updateSpecialAbilityUI(this);
     }
 


### PR DESCRIPTION
## Summary
- rely on group `runChildUpdate` by removing manual enemy iteration in DungeonScene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f74d7ba60833089edab23f647bd42