### PR TITLE
feat(ui): show primary attributes on HUD and profile

### DIFF
--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -180,7 +180,7 @@ export default class DungeonScene extends Phaser.Scene {
     }
 
     updatePlayerHud() {
-        hudUpdate(this);
+        hudUpdate(this, this.player.data.getAll());
     }
 
     updateWaveProgressText() {

--- a/src/scenes/ui.js
+++ b/src/scenes/ui.js
@@ -34,6 +34,12 @@ export default class UIScene extends Phaser.Scene {
         this.createAttributeLine(attrX, attrY, 'Dano:', this.playerData.damage, labelStyle, valueStyle); attrY += 30;
         this.createAttributeLine(attrX, attrY, 'Velocidade:', this.playerData.velocidade || this.classData.velocidade, labelStyle, valueStyle); attrY += 30;
         this.createAttributeLine(attrX, attrY, 'Cooldown Ataque:', (this.playerData.attackCooldown || this.classData.attackCooldown) + 'ms', labelStyle, valueStyle); attrY += 30;
+        this.createAttributeLine(attrX, attrY, 'Força:', this.playerData.strength ?? 0, labelStyle, valueStyle); attrY += 30;
+        this.createAttributeLine(attrX, attrY, 'Agilidade:', this.playerData.agility ?? 0, labelStyle, valueStyle); attrY += 30;
+        this.createAttributeLine(attrX, attrY, 'Inteligência:', this.playerData.intelligence ?? 0, labelStyle, valueStyle); attrY += 30;
+        if (this.playerData.attributePoints !== undefined) {
+            this.createAttributeLine(attrX, attrY, 'Pontos de Atributo:', this.playerData.attributePoints, labelStyle, valueStyle); attrY += 30;
+        }
         if (this.playerData.damageReduction) {
             this.createAttributeLine(attrX, attrY, 'Redução de Dano:', Math.round(this.playerData.damageReduction * 100) + '%', labelStyle, valueStyle); attrY += 30;
         }

--- a/src/utils/hudUtils.js
+++ b/src/utils/hudUtils.js
@@ -4,7 +4,8 @@ export function createHUD(scene) {
     scene.playerHudHpBar = scene.add.graphics();
     scene.playerHudXpBar = scene.add.graphics();
     scene.levelText = scene.add.text(10, 28, '', { fontSize:'20px', color:'#fff', stroke: '#000', strokeThickness: 4 });
-    scene.hudContainer.add([scene.playerHudHpBar, scene.playerHudXpBar, scene.levelText]);
+    scene.primaryAttrText = scene.add.text(10, 70, '', { fontSize:'18px', color:'#fff', stroke:'#000', strokeThickness:4 });
+    scene.hudContainer.add([scene.playerHudHpBar, scene.playerHudXpBar, scene.levelText, scene.primaryAttrText]);
     scene.waveProgressText = scene.add.text(scene.scale.width - 20, 20, '', { fontSize:'22px', color:'#fff', stroke:'#000', strokeThickness:4, align: 'right' }).setOrigin(1, 0).setDepth(20);
     scene.profileButton = scene.add.image(scene.scale.width - 40, 40, 'profile-icon').setInteractive({ useHandCursor: true }).setDepth(21).setScale(0.8);
     scene.profileButton.on('pointerdown', () => {
@@ -16,16 +17,25 @@ export function createHUD(scene) {
     scene.specialAbilityButton = scene.add.image(0, 0, abilityData.icon).setInteractive({ useHandCursor: true }).setDepth(21).setScale(1.2);
     scene.specialAbilityButton.on('pointerdown', () => scene.tryUseSpecialAbility());
     scene.specialAbilityCooldownText = scene.add.text(0, 0, '', { fontSize: '24px', color: '#ffffff', stroke: '#000', strokeThickness: 5 }).setOrigin(0.5).setDepth(22);
-    updatePlayerHud(scene);
+    updatePlayerHud(scene, scene.player.data.getAll());
     repositionHUD(scene, scene.scale.width, scene.scale.height);
 }
 
-export function updatePlayerHud(scene) {
-    const hp = Math.max(0, scene.player.getData('hp') / scene.player.getData('maxHp'));
+export function updatePlayerHud(scene, playerData = {}) {
+    const hp = Math.max(0, playerData.hp / playerData.maxHp);
     scene.playerHudHpBar.clear().fillStyle(0x000, 0.5).fillRoundedRect(0, 0, 204, 24, 5).fillStyle(0x00ff00).fillRoundedRect(2, 2, 200 * hp, 20, 4);
-    const xp = scene.player.getData('xp') / scene.player.getData('xpToNextLevel');
+    const xp = playerData.xp / playerData.xpToNextLevel;
     scene.playerHudXpBar.clear().fillStyle(0x000, 0.5).fillRoundedRect(0, 50, 204, 14, 5).fillStyle(0x8a2be2).fillRoundedRect(2, 52, 200 * xp, 10, 4);
-    scene.levelText.setText(`Nível: ${scene.player.getData('level')}`);
+    scene.levelText.setText(`Nível: ${playerData.level}`);
+
+    const str = playerData.strength ?? 0;
+    const agi = playerData.agility ?? 0;
+    const int = playerData.intelligence ?? 0;
+    let attrTxt = `FOR:${str} AGI:${agi} INT:${int}`;
+    if (playerData.attributePoints !== undefined) {
+        attrTxt += ` | Pts:${playerData.attributePoints}`;
+    }
+    scene.primaryAttrText.setText(attrTxt);
 }
 
 export function updateWaveProgressText(scene) {


### PR DESCRIPTION
## Summary
- display primary attributes and available points on main HUD
- show primary attributes and distribution points in profile scene
- pass player data to HUD updater to refresh new fields

## Testing
- `node --check src/utils/hudUtils.js`
- `node --check src/scenes/ui.js`
- `node --check src/scenes/dungeon.js`


------
https://chatgpt.com/codex/tasks/task_e_688f9c079d688330884f26380afd8551