### PR TITLE
refactor: centralize xp management

### DIFF
--- a/src/classes/enemy.js
+++ b/src/classes/enemy.js
@@ -2,7 +2,7 @@
 // Classe Enemy para inimigos do jogo
 // Dependências: Phaser
 
-import { gainXP, defeatTarget } from '../utils/attackUtils.js';
+import { defeatTarget } from '../utils/attackUtils.js';
 
 // --- Classe Enemy ---
 // Representa inimigos do jogo, com barra de vida e IA
@@ -92,7 +92,7 @@ export default class Enemy extends Phaser.Physics.Arcade.Sprite {
         this.healthBar.clear().fillStyle(0x000000, 0.7).fillRoundedRect(0, 0, 32, 8, 3).fillStyle(0xff0000).fillRoundedRect(1, 1, 30 * pct, 6, 2);
     }
     die() {
-        gainXP(this.scene, this.stats.xp);
+        this.scene.player.gainXP(this.stats.xp);
         if (this.healthBar) {
             this.healthBar.setActive(false).setVisible(false);
         }

--- a/src/utils/attackUtils.js
+++ b/src/utils/attackUtils.js
@@ -150,26 +150,3 @@ export function defeatTarget(scene, target) {
         scene.checkWaveCompletion();
     }
 }
-
-export function gainXP(scene, amount) {
-    let xp = scene.player.getData('xp') + amount;
-    let next = scene.player.getData('xpToNextLevel');
-    while (xp >= next) {
-        xp -= next;
-        levelUp(scene);
-        next = scene.player.getData('xpToNextLevel');
-    }
-    scene.player.setData('xp', xp);
-    scene.showFloatingText(`+${amount} XP`, scene.player.x, scene.player.y - 40, false, '#00ff7f');
-    scene.updatePlayerHud();
-}
-
-export function levelUp(scene) {
-    const p = scene.player;
-    const newLvl = p.getData('level') + 1;
-    p.setData('level', newLvl);
-    const newMaxHp = Math.floor(p.getData('maxHp') * 1.15);
-    const newDmg = Math.floor(p.getData('damage') * 1.1);
-    p.setData({ maxHp: newMaxHp, hp: newMaxHp, damage: newDmg, xpToNextLevel: Math.floor(p.getData('xpToNextLevel') * 1.5) });
-    scene.showFloatingText('LEVEL UP!', p.x, p.y, false, '#ffff00');
-}


### PR DESCRIPTION
## Summary
- remove shared gainXP and levelUp helpers
- award XP on enemy death via Player.gainXP
- ensure XP/level references rely on Player API

## Testing
- `npm test` *(fails: no such file or directory, open '/workspace/arandu/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f9c060ad48330a0296f6c6abe14a0