### PR TITLE
Refine player level-ups with class-based growth

### DIFF
--- a/src/data/data.js
+++ b/src/data/data.js
@@ -9,12 +9,14 @@ export const GameData = {
             id: 'CACADOR', nome: 'Caçador das Sombras', desc: 'Mestre do arco e das armadilhas furtivas.', cor: 0x8e44ad,
             velocidade: 230, vida: 90, dano: 22, attackType: 'ranged', attackCooldown: 350,
             critChance: 0.15, critMultiplier: 1.5,
+            growth: { vida: 8, dano: 3 },
             ability: { name: 'Chuva de Flechas', cooldown: 12000, damageMultiplier: 0.5, waves: 4, duration: 2000, radius: 120, icon: 'arrow-rain-icon' }
         },
         GUERREIRO: {
             id: 'GUERREIRO', nome: 'Guerreiro de Ossos', desc: 'A força bruta da floresta, inabalável.', cor: 0xc0392b,
             velocidade: 170, vida: 180, dano: 25, attackType: 'melee', attackRange: 80, attackCooldown: 400,
             damageReduction: 0.15,
+            growth: { vida: 15, dano: 2, defesa: 2 },
             ability: { name: 'Impacto Sísmico', cooldown: 15000, damageMultiplier: 1, stunDuration: 2000, radius: 150, icon: 'shockwave-icon' }
         }
     },

--- a/src/utils/attackUtils.js
+++ b/src/utils/attackUtils.js
@@ -152,24 +152,7 @@ export function defeatTarget(scene, target) {
 }
 
 export function gainXP(scene, amount) {
-    let xp = scene.player.getData('xp') + amount;
-    let next = scene.player.getData('xpToNextLevel');
-    while (xp >= next) {
-        xp -= next;
-        levelUp(scene);
-        next = scene.player.getData('xpToNextLevel');
-    }
-    scene.player.setData('xp', xp);
+    scene.player.gainXP(amount);
     scene.showFloatingText(`+${amount} XP`, scene.player.x, scene.player.y - 40, false, '#00ff7f');
-    scene.updatePlayerHud();
 }
 
-export function levelUp(scene) {
-    const p = scene.player;
-    const newLvl = p.getData('level') + 1;
-    p.setData('level', newLvl);
-    const newMaxHp = Math.floor(p.getData('maxHp') * 1.15);
-    const newDmg = Math.floor(p.getData('damage') * 1.1);
-    p.setData({ maxHp: newMaxHp, hp: newMaxHp, damage: newDmg, xpToNextLevel: Math.floor(p.getData('xpToNextLevel') * 1.5) });
-    scene.showFloatingText('LEVEL UP!', p.x, p.y, false, '#ffff00');
-}


### PR DESCRIPTION
## Summary
- add per-class `growth` stats and use them when leveling up
- recalculate derived player stats after leveling using `recomputeStats`
- remove duplicate `attackUtils.levelUp`, delegating XP gain to `player.gainXP`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c0321b88330b171284ce4351ecf