### PR TITLE
fix: apply level up stat increases

### DIFF
--- a/src/classes/player.js
+++ b/src/classes/player.js
@@ -117,13 +117,16 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         }
         this.setData('attributes', attrs);
 
+        // Recalcula status derivados apenas uma vez
         this.recomputeStats();
-        this.setData('hp', this.getData('maxHp')); // Cura total ao subir de nível
-        this.setData('xpToNextLevel', Math.floor(this.getData('xpToNextLevel') * 1.5));
 
-        // Recalcula HP, dano e outros atributos derivados
-        this.recomputeStats();
-        this.setData('xpToNextLevel', Math.floor(this.getData('xpToNextLevel') * 1.5));
+        // Aplica o aumento de nível e atributos calculados
+        this.setData('level', newLvl);
+        this.setData('maxHp', newMaxHp);
+        this.setData('damage', newDmg);
+        this.setData('hp', newMaxHp); // Cura total ao subir de nível
+        this.setData('xpToNextLevel', newXpToNext);
+
         this.scene.showFloatingText('LEVEL UP!', this.x, this.y, false, '#ffff00');
     }
 


### PR DESCRIPTION
## Summary
- apply computed max hp and damage increases during level up
- update xp to next level once and heal player after leveling
- drop redundant recomputeStats call

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa7a4b4788330a268d17c37c9b58e