### PR TITLE
Corrigir exibição de atributos na HUD

### DIFF
--- a/src/scenes/ui.js
+++ b/src/scenes/ui.js
@@ -34,9 +34,10 @@ export default class UIScene extends Phaser.Scene {
         this.createAttributeLine(attrX, attrY, 'Dano:', this.playerData.damage, labelStyle, valueStyle); attrY += 30;
         this.createAttributeLine(attrX, attrY, 'Velocidade:', this.playerData.velocidade || this.classData.velocidade, labelStyle, valueStyle); attrY += 30;
         this.createAttributeLine(attrX, attrY, 'Cooldown Ataque:', (this.playerData.attackCooldown || this.classData.attackCooldown) + 'ms', labelStyle, valueStyle); attrY += 30;
-        this.createAttributeLine(attrX, attrY, 'Força:', this.playerData.strength ?? 0, labelStyle, valueStyle); attrY += 30;
-        this.createAttributeLine(attrX, attrY, 'Agilidade:', this.playerData.agility ?? 0, labelStyle, valueStyle); attrY += 30;
-        this.createAttributeLine(attrX, attrY, 'Inteligência:', this.playerData.intelligence ?? 0, labelStyle, valueStyle); attrY += 30;
+        const attrs = this.playerData.attributes || {};
+        this.createAttributeLine(attrX, attrY, 'Força:', attrs.FOR ?? 0, labelStyle, valueStyle); attrY += 30;
+        this.createAttributeLine(attrX, attrY, 'Agilidade:', attrs.AGI ?? 0, labelStyle, valueStyle); attrY += 30;
+        this.createAttributeLine(attrX, attrY, 'Inteligência:', attrs.INT ?? 0, labelStyle, valueStyle); attrY += 30;
         if (this.playerData.attributePoints !== undefined) {
             this.createAttributeLine(attrX, attrY, 'Pontos de Atributo:', this.playerData.attributePoints, labelStyle, valueStyle); attrY += 30;
         }

--- a/src/utils/hudUtils.js
+++ b/src/utils/hudUtils.js
@@ -28,9 +28,10 @@ export function updatePlayerHud(scene, playerData = {}) {
     scene.playerHudXpBar.clear().fillStyle(0x000, 0.5).fillRoundedRect(0, 50, 204, 14, 5).fillStyle(0x8a2be2).fillRoundedRect(2, 52, 200 * xp, 10, 4);
     scene.levelText.setText(`Nível: ${playerData.level}`);
 
-    const str = playerData.strength ?? 0;
-    const agi = playerData.agility ?? 0;
-    const int = playerData.intelligence ?? 0;
+    const attrs = playerData.attributes || {};
+    const str = attrs.FOR ?? 0;
+    const agi = attrs.AGI ?? 0;
+    const int = attrs.INT ?? 0;
     let attrTxt = `FOR:${str} AGI:${agi} INT:${int}`;
     if (playerData.attributePoints !== undefined) {
         attrTxt += ` | Pts:${playerData.attributePoints}`;


### PR DESCRIPTION
## Summary
- Ler atributos do objeto `playerData.attributes` na HUD e no painel de UI

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fa89a0bb8833096bbdecd0999e865