### PR TITLE
Adicionar controle de pausa e ajuste de atributos

### DIFF
--- a/src/classes/player.js
+++ b/src/classes/player.js
@@ -27,6 +27,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
             level: 1,
             xp: 0,
             xpToNextLevel: 100,
+            attributePoints: 0,
             attributes: { ...this.selectedClass.baseAttributes },
             maxHp: 0,
             hp: 0,
@@ -104,7 +105,6 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     }
 
     levelUp() {
-        const newLvl = this.getData('level') + 1;
         const newMaxHp = Math.floor(this.getData('maxHp') * 1.15);
         const newDmg = Math.floor(this.getData('damage') * 1.1);
         const newXpToNext = Math.floor(this.getData('xpToNextLevel') * 1.5);
@@ -121,7 +121,8 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         this.recomputeStats();
 
         // Aplica o aumento de nível e atributos calculados
-        this.setData('level', newLvl);
+        this.setData('level', this.getData('level') + 1);
+        this.setData('attributePoints', this.getData('attributePoints') + 1);
         this.setData('maxHp', newMaxHp);
         this.setData('damage', newDmg);
         this.setData('hp', newMaxHp); // Cura total ao subir de nível

--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -53,6 +53,10 @@ export default class DungeonScene extends Phaser.Scene {
 
     create() {
         this.input.addPointer(1);
+
+        // Tecla para abrir o menu de pausa
+        this.input.keyboard.on('keydown-ESC', () => this.pauseMenu());
+
         // Desktop: auto ataque com espaço
         if (!this.sys.game.device.input.touch) {
             this.spaceAttackInterval = null;

--- a/src/utils/hudUtils.js
+++ b/src/utils/hudUtils.js
@@ -12,6 +12,15 @@ export function createHUD(scene) {
         scene.scene.pause();
         scene.scene.launch('UIScene', { playerData: scene.player.data.getAll(), classData: scene.selectedClass });
     });
+
+    // Botão de pausa
+    scene.pauseButton = scene.add.text(scene.scale.width - 40, 90, 'II', {
+        fontSize: '28px',
+        color: '#ffffff',
+        backgroundColor: '#333333',
+        padding: { top: 4, bottom: 4, left: 6, right: 6 }
+    }).setOrigin(0.5).setDepth(21).setInteractive({ useHandCursor: true });
+    scene.pauseButton.on('pointerdown', () => scene.pauseMenu());
     // Botão de habilidade especial
     const abilityData = scene.selectedClass.ability;
     scene.specialAbilityButton = scene.add.image(0, 0, abilityData.icon).setInteractive({ useHandCursor: true }).setDepth(21).setScale(1.2);
@@ -81,6 +90,7 @@ export function repositionHUD(scene, width, height) {
     if (scene.hudContainer) scene.hudContainer.setPosition(20, 20);
     if (scene.waveProgressText) scene.waveProgressText.setPosition(width - 20, 20);
     if (scene.profileButton) scene.profileButton.setPosition(width - 40, 40);
+    if (scene.pauseButton) scene.pauseButton.setPosition(width - 40, 90);
     if (scene.specialAbilityButton) {
         const yPos = scene.attackJoystick.base.y || height - 80;
         scene.specialAbilityButton.setPosition(width - 80, yPos - 80);


### PR DESCRIPTION
## Summary
- Disponibiliza botão na HUD e tecla ESC para abrir o menu de pausa
- Adiciona attributePoints ao jogador e incrementa a cada level up
- Remove variável desnecessária de levelUp

## Testing
- `npm test` *(falhou: não encontrou package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fa9d9eb7c8330a202e873163617ed