### PR TITLE
feat: add attribute distribution system

### DIFF
--- a/src/scenes/dungeon.js
+++ b/src/scenes/dungeon.js
@@ -65,7 +65,7 @@ export default class DungeonScene extends Phaser.Scene {
                     let dir = this.lastAttackDirection || new Phaser.Math.Vector2(0, -1);
                     fireAttack(this, dir);
                     this.spaceAttackInterval = this.time.addEvent({
-                        delay: this.selectedClass.attackCooldown,
+                        delay: this.player.getData('attackCooldown'),
                         loop: true,
                         callback: () => {
                             let dir = this.lastAttackDirection || new Phaser.Math.Vector2(0, -1);

--- a/src/utils/attackUtils.js
+++ b/src/utils/attackUtils.js
@@ -5,13 +5,13 @@ export function fireAttack(scene, direction) {
         const vel = scene.player.body.velocity;
         attackDir = vel.length() > 0 ? vel.clone().normalize() : new Phaser.Math.Vector2(0, -1);
     }
-    const cooldown = scene.selectedClass.attackCooldown;
+    const cooldown = scene.player.getData('attackCooldown');
     const lastAttack = scene.player.getData('lastAttack');
     if (scene.time.now < lastAttack + cooldown) return;
     scene.player.setData('lastAttack', scene.time.now);
     const prevVelocity = scene.player.body.velocity.clone();
     if (prevVelocity.length() === 0) {
-        const speed = scene.selectedClass.velocidade;
+        const speed = scene.player.getData('speed');
         scene.player.body.setVelocity(attackDir.x * speed, attackDir.y * speed);
     }
     if (scene.selectedClass.attackType === 'melee') {

--- a/src/utils/attributeUtils.js
+++ b/src/utils/attributeUtils.js
@@ -10,3 +10,16 @@ export function calcMaxHp(attrs) {
     const { VIT = 0 } = attrs;
     return 50 + VIT * 10;
 }
+
+// Calcula velocidade de movimento com base na Agilidade
+export function calcMoveSpeed(attrs, baseSpeed = 0) {
+    const { AGI = 0 } = attrs;
+    return baseSpeed + AGI * 2;
+}
+
+// Calcula cooldown de ataque reduzindo conforme a Destreza
+export function calcAttackCooldown(attrs, baseCooldown = 0) {
+    const { DES = 0 } = attrs;
+    const reduced = baseCooldown - DES * 5;
+    return Math.max(100, reduced);
+}

--- a/src/utils/controlUtils.js
+++ b/src/utils/controlUtils.js
@@ -2,7 +2,7 @@
 import { fireAttack } from './attackUtils.js';
 
 export function handleControls(scene) {
-    const speed = scene.selectedClass.velocidade;
+    const speed = scene.player.getData('speed');
     scene.player.body.setVelocity(0);
     if (scene.cursors.left.isDown) scene.player.body.setVelocityX(-speed);
     else if (scene.cursors.right.isDown) scene.player.body.setVelocityX(speed);
@@ -24,7 +24,7 @@ export function startJoystickAutoAttack(scene) {
         let dir = scene.attackJoystick.fireDirection || new Phaser.Math.Vector2(0, -1);
         fireAttack(scene, dir);
         scene.joystickAttackInterval = scene.time.addEvent({
-            delay: scene.selectedClass.attackCooldown,
+            delay: scene.player.getData('attackCooldown'),
             loop: true,
             callback: () => {
                 let dir = scene.attackJoystick.fireDirection || new Phaser.Math.Vector2(0, -1);

--- a/src/utils/hudUtils.js
+++ b/src/utils/hudUtils.js
@@ -40,8 +40,10 @@ export function updatePlayerHud(scene, playerData = {}) {
     const attrs = playerData.attributes || {};
     const str = attrs.FOR ?? 0;
     const agi = attrs.AGI ?? 0;
-    const int = attrs.INT ?? 0;
-    let attrTxt = `FOR:${str} AGI:${agi} INT:${int}`;
+    const vit = attrs.VIT ?? 0;
+    const des = attrs.DES ?? 0;
+    const sor = attrs.SOR ?? 0;
+    let attrTxt = `FOR:${str} AGI:${agi} VIT:${vit} DES:${des} SOR:${sor}`;
     if (playerData.attributePoints !== undefined) {
         attrTxt += ` | Pts:${playerData.attributePoints}`;
     }


### PR DESCRIPTION
## Summary
- compute speed and attack cooldown from attributes
- grant and spend attribute points on level up
- refresh HUD and profile UI with editable attributes

## Testing
- `node --check src/utils/attributeUtils.js`
- `node --check src/classes/player.js`
- `node --check src/utils/controlUtils.js`
- `node --check src/utils/attackUtils.js`
- `node --check src/scenes/dungeon.js`
- `node --check src/utils/hudUtils.js`
- `node --check src/scenes/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_688faf833e148330b10ea9b1eee17ddd