### PR TITLE
feat: exibir texto de dano flutuante

### DIFF
--- a/src/components/DamageTextManager.ts
+++ b/src/components/DamageTextManager.ts
@@ -1,0 +1,74 @@
+import Phaser, { Scene, Physics } from 'phaser';
+
+type DamageTextStyle = {
+    readonly fill: string;
+    readonly stroke: string;
+};
+
+/**
+ * Gera textos flutuantes para comunicar dano diretamente na cena.
+ * Utiliza pooling para evitar alocações excessivas em cenários com muitos acertos.
+ */
+export class DamageTextManager {
+    private readonly scene: Scene;
+    private readonly pool: Phaser.GameObjects.Group;
+    private readonly styles: Record<'player' | 'enemy', DamageTextStyle>;
+
+    constructor(scene: Scene) {
+        this.scene = scene;
+        this.pool = this.scene.add.group({ classType: Phaser.GameObjects.Text });
+        this.styles = {
+            player: { fill: '#ffe066', stroke: '#2f2f2f' },
+            enemy: { fill: '#ff6b6b', stroke: '#1f1f1f' },
+        };
+    }
+
+    public showDamage(target: Physics.Arcade.Sprite, amount: number, type: 'player' | 'enemy'): void {
+        const text = this.acquireText();
+        const style = this.styles[type];
+
+        text.setText(Math.round(amount).toString());
+        text.setPosition(target.x, target.y - target.displayHeight * 0.75);
+        text.setOrigin(0.5, 1);
+        text.setDepth(1000);
+        text.setStyle({
+            fontFamily: 'Press Start 2P, monospace',
+            fontSize: '12px',
+            color: style.fill,
+            stroke: style.stroke,
+            strokeThickness: 4,
+        });
+        text.setAlpha(1);
+
+        this.scene.tweens.add({
+            targets: text,
+            y: text.y - 16,
+            alpha: 0,
+            duration: 400,
+            ease: Phaser.Math.Easing.Cubic.Out,
+            onComplete: () => {
+                this.releaseText(text);
+            },
+        });
+    }
+
+    private acquireText(): Phaser.GameObjects.Text {
+        const existing = this.pool.getFirstDead(false) as Phaser.GameObjects.Text | null;
+        if (existing) {
+            existing.setActive(true);
+            existing.setVisible(true);
+            return existing;
+        }
+
+        const created = this.scene.add.text(0, 0, '');
+        created.setPadding(2, 2, 2, 2);
+        this.pool.add(created);
+        return created;
+    }
+
+    private releaseText(text: Phaser.GameObjects.Text): void {
+        this.pool.killAndHide(text);
+        text.setActive(false);
+        text.setVisible(false);
+    }
+}

--- a/src/components/HealthComponent.ts
+++ b/src/components/HealthComponent.ts
@@ -1,4 +1,5 @@
 import { Scene, Physics } from 'phaser';
+import { DamageTextManager } from './DamageTextManager';
 
 // Encapsula regras de vida e feedback visual, facilitando reuso em diferentes entidades.
 export class HealthComponent {
@@ -7,13 +8,15 @@ export class HealthComponent {
     private readonly maxHealth: number;
     private _health: number;
     private damageTween: Phaser.Tweens.Tween | null = null;
+    private readonly damageTextManager?: DamageTextManager;
 
     // Recebe todas as dependências via construtor para manter o componente independente.
-    constructor(scene: Scene, entity: Physics.Arcade.Sprite, initialHealth: number) {
+    constructor(scene: Scene, entity: Physics.Arcade.Sprite, initialHealth: number, damageTextManager?: DamageTextManager) {
         this.scene = scene;
         this.entity = entity;
         this._health = initialHealth;
         this.maxHealth = initialHealth;
+        this.damageTextManager = damageTextManager;
 
         // Emite o valor inicial garantindo que UI e sistemas fiquem sincronizados desde o spawn.
         this.emitHealthChanged();
@@ -50,6 +53,7 @@ export class HealthComponent {
         this._health = Math.max(0, this._health - amount);
         this.emitHealthChanged();
         this.playDamageEffect();
+        this.spawnDamageText(amount);
 
         if (!this.isAlive()) {
             this.handleDeath();
@@ -73,6 +77,15 @@ export class HealthComponent {
                 this.entity.setAlpha(1);
             }
         });
+    }
+
+    private spawnDamageText(amount: number): void {
+        if (!this.damageTextManager) {
+            return;
+        }
+
+        const type = this.isPlayer() ? 'player' : 'enemy';
+        this.damageTextManager.showDamage(this.entity, amount, type);
     }
 
     private handleDeath(): void {

--- a/src/factories/EnemyFactory.ts
+++ b/src/factories/EnemyFactory.ts
@@ -1,6 +1,7 @@
 import { Scene, Physics } from 'phaser';
 import { HealthComponent } from '../components/HealthComponent';
 import { ConfigService } from '../config/ConfigService';
+import { DamageTextManager } from '../components/DamageTextManager';
 
 export class EnemyFactory {
     /**
@@ -10,13 +11,13 @@ export class EnemyFactory {
      * @param y A posição inicial Y do inimigo.
      * @returns O sprite do inimigo com física habilitada.
      */
-    public static create(scene: Scene, x: number, y: number): Physics.Arcade.Sprite {
+    public static create(scene: Scene, x: number, y: number, damageTextManager: DamageTextManager): Physics.Arcade.Sprite {
         const enemy = scene.physics.add.sprite(x, y, 'enemy');
         enemy.setCollideWorldBounds(true);
 
         // Anexa o HealthComponent ao Data Manager do sprite.
         const enemyConfig = ConfigService.getInstance().getEnemyConfig();
-        enemy.setData('health', new HealthComponent(scene, enemy, enemyConfig.maxHealth));
+        enemy.setData('health', new HealthComponent(scene, enemy, enemyConfig.maxHealth, damageTextManager));
 
         return enemy;
     }

--- a/src/factories/PlayerFactory.ts
+++ b/src/factories/PlayerFactory.ts
@@ -1,15 +1,16 @@
 import { Scene, Physics } from 'phaser';
 import { HealthComponent } from '../components/HealthComponent';
 import { ConfigService } from '../config/ConfigService';
+import { DamageTextManager } from '../components/DamageTextManager';
 
 export class PlayerFactory {
-    public static create(scene: Scene, x: number, y: number): Physics.Arcade.Sprite {
+    public static create(scene: Scene, x: number, y: number, damageTextManager: DamageTextManager): Physics.Arcade.Sprite {
         const player = scene.physics.add.sprite(x, y, 'player', 'player-idle-1');
         player.setCollideWorldBounds(true);
 
         // Anexa o HealthComponent ao Data Manager do sprite.
         const playerConfig = ConfigService.getInstance().getCharacterConfig();
-        player.setData('health', new HealthComponent(scene, player, playerConfig.maxHealth));
+        player.setData('health', new HealthComponent(scene, player, playerConfig.maxHealth, damageTextManager));
 
         // Cria as animações do jogador
         scene.anims.create({

--- a/src/scenes/DungeonScene.ts
+++ b/src/scenes/DungeonScene.ts
@@ -6,6 +6,7 @@ import { MovementSystem } from '../systems/MovementSystem';
 import { CollisionSystem } from '../systems/CollisionSystem';
 import { EnemyAISystem } from '../systems/EnemyAISystem';
 import { AttackSystem } from '../systems/AttackSystem';
+import { DamageTextManager } from '../components/DamageTextManager';
 
 export class DungeonScene extends Scene {
     private player!: Physics.Arcade.Sprite;
@@ -17,6 +18,7 @@ export class DungeonScene extends Scene {
     private cursors!: Types.Input.Keyboard.CursorKeys;
     private map!: Tilemaps.Tilemap;
     private wallsLayer!: Tilemaps.TilemapLayer | null;
+    private damageTextManager!: DamageTextManager;
 
     constructor() {
         super('DungeonScene');
@@ -37,10 +39,12 @@ export class DungeonScene extends Scene {
             this.wallsLayer?.setCollisionByProperty({ collides: true });
         }
 
-        this.player = PlayerFactory.create(this, 100, 120);
+        this.damageTextManager = new DamageTextManager(this);
+
+        this.player = PlayerFactory.create(this, 100, 120, this.damageTextManager);
 
         this.enemies = this.physics.add.group();
-        const enemy1 = EnemyFactory.create(this, 250, 120);
+        const enemy1 = EnemyFactory.create(this, 250, 120, this.damageTextManager);
         this.enemies.add(enemy1);
 
         if (this.wallsLayer) {


### PR DESCRIPTION
## Resumo
- criar DamageTextManager para exibir números de dano reutilizando textos via pool
- integrar o gerenciador aos componentes de vida do jogador e inimigos
- inicializar o gerenciador na cena da masmorra e repassar via factories