### PR TITLE
Atualiza velocidade de movimento conforme progressão

### DIFF
--- a/src/systems/AnimationSystem.ts
+++ b/src/systems/AnimationSystem.ts
@@ -2,9 +2,27 @@ import { Physics } from 'phaser';
 
 export class AnimationSystem {
     private entity: Physics.Arcade.Sprite;
+    private baseMovementSpeed: number | null = null;
 
     constructor(entity: Physics.Arcade.Sprite) {
         this.entity = entity;
+    }
+
+    public setBaseMovementSpeed(speed: number): void {
+        this.baseMovementSpeed = speed;
+    }
+
+    public onMovementSpeedChanged(newSpeed: number): void {
+        if (!this.entity.anims) {
+            return;
+        }
+
+        if (!this.baseMovementSpeed || this.baseMovementSpeed <= 0) {
+            this.baseMovementSpeed = newSpeed;
+        }
+
+        const normalizedSpeed: number = Math.max(0.1, newSpeed / this.baseMovementSpeed);
+        this.entity.anims.timeScale = normalizedSpeed;
     }
 
     public update(): void {


### PR DESCRIPTION
## Resumo
- ajusta o MovementSystem para ouvir o evento player-progression-updated e atualizar a velocidade corrente
- sincroniza o AnimationSystem com a nova velocidade para ajustar o playback das animações
- remove o listener ao destruir a cena para evitar vazamentos de memória

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e99469e7888330b3eed3a5885f8768