### PR TITLE
Ajusta layout responsivo do container do jogo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arandú</title>
     <style>
-      html,
+      html {
+        height: 100%;
+      }
+
       body {
         margin: 0;
         padding: 0;
+        min-height: 100vh;
         width: 100%;
-        height: 100%;
         overflow: hidden;
         background-color: #000;
       }
-      canvas {
+
+      #game-container {
+        position: relative;
+        width: 100vw;
+        height: 100vh;
+        padding: env(safe-area-inset-top) env(safe-area-inset-right)
+          env(safe-area-inset-bottom) env(safe-area-inset-left);
+      }
+
+      #game-container canvas {
         display: block;
+        width: 100%;
+        height: 100%;
       }
     </style>
   </head>

--- a/src/scenes/Preloader.ts
+++ b/src/scenes/Preloader.ts
@@ -18,6 +18,7 @@ export class Preloader extends Scene {
     }
 
     public create(): void {
+        this.scale.refresh();
         this.scene.start('DungeonScene');
     }
 }


### PR DESCRIPTION
## Resumo
- adiciona estilos responsivos ao body e ao contêiner do jogo para ocupar toda a viewport com suporte a notch
- força o canvas a escalar via CSS para reduzir cálculos manuais de escala
- garante atualização da escala do Phaser na inicialização para respeitar a nova área útil

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9a06a33d48330a931ce610a1205e4