### PR TITLE
Ajusta estratégia responsiva do HUD

### DIFF
--- a/src/scenes/hud/HudLayoutAdapter.ts
+++ b/src/scenes/hud/HudLayoutAdapter.ts
@@ -1,0 +1,44 @@
+import Phaser from 'phaser';
+
+export interface HudLayoutMetrics {
+    readonly fontScale: number;
+    readonly trackHeight: number;
+    readonly maxWidth: number;
+}
+
+export class HudLayoutAdapter {
+    private readonly baseSize: Phaser.Structs.Size;
+    private readonly epsilon: number;
+
+    public constructor(baseSize: Phaser.Structs.Size = new Phaser.Structs.Size(1280, 720), epsilon: number = 0.001) {
+        this.baseSize = baseSize;
+        this.epsilon = epsilon;
+    }
+
+    public calculateMetrics(displaySize: Phaser.Structs.Size): HudLayoutMetrics {
+        const widthRatio: number = displaySize.width / this.baseSize.width;
+        const heightRatio: number = displaySize.height / this.baseSize.height;
+        const fontScale: number = Phaser.Math.Clamp(Math.min(widthRatio, heightRatio), 0.75, 1.2);
+        const trackHeight: number = Phaser.Math.Clamp(12 * fontScale, 8, 18);
+        const availableWidth: number = Math.max(displaySize.width - 24, 280);
+        const maxWidth: number = Math.min(520 * fontScale, availableWidth);
+
+        return { fontScale, trackHeight, maxWidth };
+    }
+
+    public hasSignificantChange(current: HudLayoutMetrics | undefined, next: HudLayoutMetrics): boolean {
+        if (!current) {
+            return true;
+        }
+
+        return (
+            this.hasDifference(current.fontScale, next.fontScale) ||
+            this.hasDifference(current.trackHeight, next.trackHeight) ||
+            this.hasDifference(current.maxWidth, next.maxWidth)
+        );
+    }
+
+    public hasDifference(a: number, b: number): boolean {
+        return Math.abs(a - b) > this.epsilon;
+    }
+}


### PR DESCRIPTION
## Resumo
- cria HudLayoutAdapter para calcular métricas do HUD com base no displaySize exibido
- evita repaints desnecessários ao atualizar estilos apenas quando as métricas mudam
- ajusta breakpoints responsivos do HUD para diferentes larguras de tela

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9a1635f5083308d93e539ba507e82