### PR TITLE
Ajusta cálculo de largura do HUD

### DIFF
--- a/src/scenes/hud/HudLayoutAdapter.ts
+++ b/src/scenes/hud/HudLayoutAdapter.ts
@@ -20,8 +20,10 @@ export class HudLayoutAdapter {
         const heightRatio: number = displaySize.height / this.baseSize.height;
         const fontScale: number = Phaser.Math.Clamp(Math.min(widthRatio, heightRatio), 0.75, 1.2);
         const trackHeight: number = Phaser.Math.Clamp(12 * fontScale, 8, 18);
-        const availableWidth: number = Math.max(displaySize.width - 24, 280);
-        const maxWidth: number = Math.min(520 * fontScale, availableWidth);
+        const margin: number = 24;
+        const availableWidth: number = Math.max(displaySize.width - margin, 200);
+        const targetWidth: number = Phaser.Math.Clamp(280 * fontScale, 200, 320);
+        const maxWidth: number = Math.min(targetWidth, availableWidth);
 
         return { fontScale, trackHeight, maxWidth };
     }


### PR DESCRIPTION
## Resumo
- reduz a largura-alvo do HUD para 280px com clamp entre 200px e 320px
- garante que a largura máxima respeite as margens disponíveis do display

## Testes
- não executados (ajuste estático)


------
https://chatgpt.com/codex/tasks/task_e_68e9a5a91ac083308b32438262dc832e