### PR TITLE
Ajusta container do HUD para ocupar canvas

### DIFF
--- a/src/scenes/UIScene.ts
+++ b/src/scenes/UIScene.ts
@@ -582,6 +582,14 @@ export class UIScene extends Scene {
         `;
         dom.createFromHTML(html);
 
+        const containerElement: HTMLElement = dom.node as HTMLElement;
+        containerElement.style.display = 'block';
+        containerElement.style.width = '100%';
+        containerElement.style.height = '100%';
+        containerElement.style.left = '0';
+        containerElement.style.top = '0';
+        containerElement.style.pointerEvents = 'none';
+
         const rootElement = dom.node as HTMLElement;
         const waveElement = this.queryHudElement(rootElement, '[data-hud="wave"]');
         this.hudElements = {


### PR DESCRIPTION
## Sumário
- garante que o container do HUD ocupe o canvas inteiro e não capture eventos de ponteiro
- mantém elementos interativos com pointer-events ativos por meio das classes existentes

## Testes
- não executado (ambiente não solicitado)


------
https://chatgpt.com/codex/tasks/task_e_68e9cebabafc833082e32f014bd46fc9