### PR TITLE
refactor: centraliza leitura de PlayerStats

### DIFF
--- a/src/systems/AttackSystem.ts
+++ b/src/systems/AttackSystem.ts
@@ -1,6 +1,7 @@
 import { Scene, Physics } from 'phaser';
 import { HealthComponent } from '../components/HealthComponent';
 import type { PlayerAttackDerivedStats, PlayerStats } from '../config/types';
+import { getRequiredPlayerStats } from './utils/getRequiredPlayerStats';
 import type { PlayerProgressionUpdatePayload } from './PlayerProgressionSystem';
 
 export class AttackSystem {
@@ -18,7 +19,7 @@ export class AttackSystem {
         this.scene = scene;
         this.player = player;
         this.attackKey = this.scene.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
-        const playerStats: PlayerStats = this.extractStats(player);
+        const playerStats: PlayerStats = getRequiredPlayerStats(player);
         this.attackStats = { ...playerStats.attack };
         this.randomGenerator = new Phaser.Math.RandomDataGenerator();
         this.sceneEvents = this.scene.game.events;
@@ -88,15 +89,6 @@ export class AttackSystem {
         return hitbox;
     }
 
-    private extractStats(player: Physics.Arcade.Sprite): PlayerStats {
-        const stats = player.getData('stats') as PlayerStats | undefined;
-        if (!stats) {
-            throw new Error('PlayerStats não inicializados no sprite do jogador.');
-        }
-
-        return stats;
-    }
-
     private rollDamage(): { damage: number; isCritical: boolean } {
         const roll = this.randomGenerator.realInRange(0, 100);
         const isCritical = roll < this.attackStats.criticalChance;
@@ -106,7 +98,7 @@ export class AttackSystem {
     }
 
     private onPlayerProgressionUpdated(_payload: PlayerProgressionUpdatePayload): void {
-        const updatedStats: PlayerStats = this.extractStats(this.player);
+        const updatedStats: PlayerStats = getRequiredPlayerStats(this.player);
         this.attackStats = { ...updatedStats.attack };
     }
 

--- a/src/systems/MovementSystem.ts
+++ b/src/systems/MovementSystem.ts
@@ -2,6 +2,7 @@ import Phaser, { Physics } from 'phaser';
 import type { Types } from 'phaser';
 import { AnimationSystem } from './AnimationSystem';
 import type { PlayerStats } from '../config/types';
+import { getRequiredPlayerStats } from './utils/getRequiredPlayerStats';
 import type { PlayerProgressionUpdatePayload } from './PlayerProgressionSystem';
 
 export class MovementSystem {
@@ -17,7 +18,7 @@ export class MovementSystem {
         this.cursors = cursors;
         this.player = player;
         this.animationSystem = new AnimationSystem(this.player);
-        const initialStats: PlayerStats = this.extractStats(player);
+        const initialStats: PlayerStats = getRequiredPlayerStats(player);
         this.baseSpeed = initialStats.movementSpeed;
         this.currentSpeed = initialStats.movementSpeed;
         this.animationSystem.setBaseMovementSpeed(this.baseSpeed);
@@ -50,17 +51,8 @@ export class MovementSystem {
         this.animationSystem.update();
     }
 
-    private extractStats(player: Physics.Arcade.Sprite): PlayerStats {
-        const stats = player.getData('stats') as PlayerStats | undefined;
-        if (!stats) {
-            throw new Error('PlayerStats não inicializados no sprite do jogador.');
-        }
-
-        return stats;
-    }
-
     private handleProgressionUpdated(_: PlayerProgressionUpdatePayload): void {
-        this.currentSpeed = this.extractStats(this.player).movementSpeed;
+        this.currentSpeed = getRequiredPlayerStats(this.player).movementSpeed;
         this.animationSystem.onMovementSpeedChanged(this.currentSpeed);
     }
 

--- a/src/systems/utils/getRequiredPlayerStats.ts
+++ b/src/systems/utils/getRequiredPlayerStats.ts
@@ -1,0 +1,11 @@
+import type { Physics } from 'phaser';
+import type { PlayerStats } from '../../config/types';
+
+export const getRequiredPlayerStats = (player: Physics.Arcade.Sprite): PlayerStats => {
+    const stats = player.getData('stats') as PlayerStats | undefined;
+    if (!stats) {
+        throw new Error('PlayerStats não inicializados no sprite do jogador.');
+    }
+
+    return stats;
+};


### PR DESCRIPTION
## Resumo
- cria helper puro `getRequiredPlayerStats` para garantir presença de `PlayerStats`
- substitui duplicação em `MovementSystem` e `AttackSystem` pelo utilitário compartilhado

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9e21ce3d08330a072ab19878698fa